### PR TITLE
workaround collapse items in table

### DIFF
--- a/styles_src/q-table.scss
+++ b/styles_src/q-table.scss
@@ -125,13 +125,13 @@ td.q-table__cell--numeric {
 }
 
 tr.q-table-state-hidden {
-  visibility: collapse;
+  display: none;
 }
 
 tr.q-table-state-visible {
-  visibility: visible !important;
+  display: table-row !important;
 }
 
 .q-table--card-layout tr.q-table-state-visible {
-  visibility: visible !important;
+  display: table-row !important;
 }

--- a/views/table.html
+++ b/views/table.html
@@ -15,7 +15,7 @@
     {%- endif %}
     <tbody class="s-font-note">
       {%- for row in item.data.slice(1) %}
-      <tr {% if numberOfRowsToHide and loop.index >= (item.data.length - numberOfRowsToHide) %}style="visibility: collapse"{% endif %}>
+      <tr {% if numberOfRowsToHide and loop.index >= (item.data.length - numberOfRowsToHide) %}style="display: none;"{% endif %}>
         {%- for cell in row %}
         <td 
           {% if item.options.hideTableHeader !== true %}data-label="{{ item.data[0][loop.index0].value }}" {% endif %} 


### PR DESCRIPTION
Workaround for the white-block which was shown in Safari-Mobile because of the visibility: collapse