### PR TITLE
remove footnote-list from footer

### DIFF
--- a/styles_src/q-table.scss
+++ b/styles_src/q-table.scss
@@ -290,3 +290,7 @@ tr.q-table-state-visible {
     padding-right: 16px!important;
   }
 }
+
+.q-table-footer-footnote {
+  margin-top: 4px;
+}

--- a/views/footer.html
+++ b/views/footer.html
@@ -23,15 +23,4 @@
 
     {%- endfor %}
   {%- endif %}
-  {%- if footnotes.length > 0 %}
-    {%- for footnote in footnotes -%}
-      <div class="q-table-footer-footnote">
-        <span class="q-table-footnote-index"
-        {%- if loop.index >= 10 -%}
-          style="width: 9px!important"
-        {%- endif -%}>
-        {{loop.index}}</span><span class="q-table-footnote-text"> {{footnote.data.footnote}}</span>
-      </div>
-    {%- endfor -%}
-  {%- endif -%}
 </div>

--- a/views/table.html
+++ b/views/table.html
@@ -43,5 +43,16 @@
       </tbody>
     </table>
   </div>
+  {%- if footnotes.length > 0 %}
+    {%- for footnote in footnotes -%}
+      <div class="q-table-footer-footnote s-font-note-s">
+        <span class="q-table-footnote-index"
+        {%- if loop.index >= 10 -%}
+          style="width: 9px!important"
+        {%- endif -%}>
+        {{loop.index}}</span><span class="q-table-footnote-text"> {{footnote.data.footnote}}</span>
+      </div>
+    {%- endfor -%}
+  {%- endif -%}
   {% include "./footer.html" %}
 </div>


### PR DESCRIPTION
Based on the changes of [this issue](https://github.com/nzzdev/Q-server-nzz/issues/289), we decided to remove the footnotes from the footer and replace them inside the `q_table`-div. This will ease the effort to replace the footer in the q-server process.