### PR TITLE
Fix methodbox customcolor

### DIFF
--- a/helpers/data.js
+++ b/helpers/data.js
@@ -73,7 +73,7 @@ function getNumericColumns(data) {
   // data[0].length is undefined when creating a new item
   if (data[0] !== undefined) {
     Array2D.forRow(data, 0, (cell, rowIndex, columnIndex) => {
-      if (columns[columnIndex].isNumeric) {
+      if (columns[columnIndex] && columns[columnIndex].isNumeric) {
         numericColumns.push({ title: cell, index: columnIndex });
       }
     });
@@ -101,7 +101,7 @@ function getTableData(data, footnotes, options) {
       let type = "text";
       let value = cell;
       let classes = [];
-      if (columns[columnIndex].isNumeric) {
+      if (columns[columnIndex] && columns[columnIndex].isNumeric) {
         type = "numeric";
         classes.push("s-font-note--tabularnums");
 

--- a/views/MethodBox.svelte
+++ b/views/MethodBox.svelte
@@ -19,8 +19,7 @@
               />
             {:else}
               <div
-                class="q-table-methods-circle-static s-legend-item-label__item__icon s-legend-item-label__item__icon--default {bucket
-                  .color.colorClass}"
+                class="q-table-methods-circle-static s-legend-item-label__item__icon s-legend-item-label__item__icon--default {bucket.color.colorClass}"
               />
             {/if}
             <div
@@ -52,14 +51,16 @@
         {#each colorColumn.methodBox.formattedBuckets as bucket, bucketIndex}
           <tr>
             <td>
-              {#if bucket.color.colorClass}
-                <div
-                  class="{bucket.color
-                    .colorClass} q-table-methods-circle q-table-methods-circle--circle-fill"
-                />
-              {:else}
-                <div style="color: {bucket.color.customColor}" />
-              {/if}
+              <div
+                class="{bucket.color.colorClass !== undefined
+                  ? bucket.color.colorClass
+                  : ''}
+                q-table-methods-circle
+                q-table-methods-circle--circle-fill"
+                style="color: {bucket.color.customColor !== undefined
+                  ? bucket.color.customColor
+                  : ''}"
+              />
             </td>
             {#if bucketIndex === 0 && colorColumn.legendData.hasSingleValueBucket}
               <td />


### PR DESCRIPTION
Custom colors were not correctly displayed in the method box. Used [the exact same code](https://github.com/nzzdev/Q-choropleth/blob/2fa3092492c8e9e9c220cbe9313501388c7ddbd7/views/MethodBox.svelte#L99) from the Choropleth-Tool to fix this.

Branch deployed on Stage.

Original table with missing custom colors in method box: https://q.st.nzz.ch/editor/table/81caa0242fa168d128995977cd45268b